### PR TITLE
ci: weekly auto-update of vendor icons via PR

### DIFF
--- a/.github/workflows/update-icons.yml
+++ b/.github/workflows/update-icons.yml
@@ -1,0 +1,149 @@
+name: Update icons data
+
+# Bumps every vendor submodule to its latest upstream commit, rebuilds dist/
+# with the pipeline, sanity-checks the result, and opens a PR. The actual data
+# change always lands via that PR so a human eyeballs the diff before
+# icons.grida.co serves it. No secrets are required — every source is a git
+# submodule.
+
+on:
+  schedule:
+    # Mondays 06:00 UTC.
+    - cron: "0 6 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+
+concurrency:
+  group: icons-refresh
+  cancel-in-progress: false
+
+jobs:
+  refresh:
+    # Don't run on forks — they can't open PRs against this repo and would just
+    # spam failures.
+    if: github.repository == 'gridaco/icons'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          fetch-depth: 1
+
+      - name: Bump vendor submodules to latest upstream
+        run: |
+          git submodule update --remote
+          echo "## Submodule pointers" >> "$GITHUB_STEP_SUMMARY"
+          git submodule status >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Record pre-build vendor counts
+        # Snapshot the committed data.json counts so the regression gate below
+        # can tell a real upstream removal from a pipeline that silently broke.
+        run: |
+          for v in radix-ui-icons heroicons lucide-icons phosphor-icons octicons svgl; do
+            f="dist/$v/data.json"
+            n=$(python3 -c "import json,sys;print(len(json.load(open('$f')).get('files',[])))" 2>/dev/null || echo 0)
+            echo "$v $n"
+          done > /tmp/icons_counts_before.txt
+          cat /tmp/icons_counts_before.txt
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+
+      - name: Rebuild dist
+        working-directory: pipeline
+        run: uv run main.py dist
+
+      - name: Validate dist (intrinsic)
+        working-directory: pipeline
+        run: uv run main.py validate
+
+      - name: Regression gate (no vendor may crater)
+        # validate already fails on an empty/mismatched vendor; this additionally
+        # catches a *partial* drop (e.g. one of phosphor's weight folders moving
+        # upstream) that wouldn't zero a vendor but is still almost certainly a bug.
+        run: |
+          fail=0
+          while read -r v before; do
+            f="dist/$v/data.json"
+            after=$(python3 -c "import json;print(len(json.load(open('$f')).get('files',[])))")
+            echo "$v: $before -> $after"
+            if [ "$before" -gt 0 ] && [ "$after" -lt $((before * 3 / 4)) ]; then
+              echo "::error::$v dropped from $before to $after (>25%) — likely upstream path drift, not a real removal"
+              fail=1
+            fi
+          done < /tmp/icons_counts_before.txt
+          exit $fail
+
+      - name: Summarize changes
+        id: summary
+        run: |
+          {
+            echo "summary<<EOF"
+            echo "### Vendor counts (before -> after)"
+            while read -r v before; do
+              after=$(python3 -c "import json;print(len(json.load(open('dist/$v/data.json')).get('files',[])))")
+              echo "- $v: $before -> $after"
+            done < /tmp/icons_counts_before.txt
+            echo ""
+            echo "### dist diff"
+            git add -A dist >/dev/null 2>&1 || true
+            git diff --cached --stat dist | tail -1
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+          git reset -q dist || true
+
+      - name: Create pull request
+        uses: peter-evans/create-pull-request@v7
+        with:
+          commit-message: "chore(data): refresh icons data"
+          branch: bot/icons-update
+          delete-branch: true
+          title: "chore(data): refresh icons data"
+          body: |
+            Automated refresh: vendor submodules bumped to latest upstream and
+            `dist/` rebuilt via `pipeline` (`uv run main.py dist`), validated with
+            `uv run main.py validate`.
+
+            Note: each vendor's `version` field in `data.json` is template-pinned
+            (see `pipeline/templates/*.spec.json`) and is **not** auto-derived from
+            the submodule — bump it by hand when an upstream cuts a release worth
+            labelling.
+
+            ${{ steps.summary.outputs.summary }}
+          labels: |
+            bot:icons-refresh
+
+      - name: Open or update failure issue
+        if: failure()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const title = "[bot] icons refresh failing";
+            const label = "bot:icons-refresh";
+            const runUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const body = `Run [${context.runId}](${runUrl}) failed on \`${context.sha.slice(0,7)}\`.\n\nMost likely a vendor submodule restructured its folders and a hard-coded source path in \`pipeline/main.py\` (the \`dist\` builder) now points at nothing — check the **Validate dist** / **Regression gate** step output.`;
+
+            const { data: issues } = await github.rest.issues.listForRepo({
+              owner: context.repo.owner, repo: context.repo.repo,
+              state: "open", labels: label, per_page: 5,
+            });
+            const existing = issues.find(i => i.title === title);
+
+            if (existing) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner, repo: context.repo.repo,
+                issue_number: existing.number, body,
+              });
+            } else {
+              await github.rest.issues.create({
+                owner: context.repo.owner, repo: context.repo.repo,
+                title, body, labels: [label],
+              });
+            }

--- a/pipeline/README.md
+++ b/pipeline/README.md
@@ -28,6 +28,17 @@ Run from `pipeline/` (or prefix with `uv run pipeline/main.py ...` from repo roo
 
 Each command writes metadata to `.cache/<vendor>/metadata.json` by default. Use `--out <dir>` on individual vendor commands to override.
 
+### Build + validate
+
+- `uv run main.py dist` — clean, re-cache all vendors, and build the published `dist/` (SVGs + per-vendor `data.json` + merged `LICENSE`).
+- `uv run main.py validate` — sanity-check a built `dist/`: every vendor's `data.json` must parse, list >0 files, and have an entry count matching the `.svg` files in `dist/<vendor>/src`. Exits non-zero on failure. This is the gate that catches an upstream submodule moving its folders out from under a hard-coded source path in `dist` (which would otherwise ship an empty vendor silently).
+
+## Auto-update
+
+[`.github/workflows/update-icons.yml`](../.github/workflows/update-icons.yml) runs weekly (and on demand via *workflow_dispatch*): it bumps every `vendor/*` submodule to latest upstream, runs `dist`, runs `validate` plus a regression gate (fails if any vendor's count drops >25%), and opens a PR (`bot/icons-update`). The data change always lands via that PR. No secrets are needed.
+
+> The `version` field in each `data.json` comes from `templates/<vendor>.spec.json` and is **not** auto-derived from the submodule — bump it by hand when an upstream cuts a release worth labelling.
+
 ## Outputs (per vendor)
 
 - All commands write to `.cache/<vendor>/metadata.json` by default (override with `--out <dir>` on the specific vendor command).

--- a/pipeline/main.py
+++ b/pipeline/main.py
@@ -291,10 +291,78 @@ def clean():
     click.echo("Dist directory reset with placeholders (.gitkeep, README.md).")
 
 
+# Vendors that must be present in a healthy dist build.
+DIST_VENDORS = [
+    "radix-ui-icons",
+    "heroicons",
+    "lucide-icons",
+    "phosphor-icons",
+    "octicons",
+    "svgl",
+]
+
+
+@click.command(name="validate")
+def validate():
+    """
+    Sanity-check the built dist/ before publishing.
+
+    For each vendor asserts that data.json exists and parses, that it lists at
+    least one file, and that the number of file entries matches the number of
+    .svg assets actually copied into dist/<vendor>/src. A zero count or a
+    mismatch usually means an upstream submodule restructured its folders and a
+    hard-coded source path in the `dist` builder now points at nothing — the
+    failure mode that would otherwise ship an empty vendor silently.
+    """
+    errors: list[str] = []
+    click.echo(f"{'vendor':<18}{'entries':>9}{'svgs':>8}  status")
+    for vendor in DIST_VENDORS:
+        vdir = DIST_DIR / vendor
+        data_path = vdir / "data.json"
+        if not data_path.exists():
+            errors.append(f"{vendor}: data.json missing")
+            click.echo(f"{vendor:<18}{'MISSING':>9}")
+            continue
+        try:
+            data = json.loads(data_path.read_text())
+        except Exception as e:
+            errors.append(f"{vendor}: data.json invalid JSON ({e})")
+            click.echo(f"{vendor:<18}{'BADJSON':>9}")
+            continue
+
+        files = data.get("files") or []
+        n_entries = len(files)
+        src_dir = vdir / "src"
+        n_svgs = (
+            sum(1 for p in src_dir.rglob("*.svg") if p.is_file())
+            if src_dir.exists()
+            else 0
+        )
+
+        status = "ok"
+        if n_entries == 0:
+            errors.append(f"{vendor}: 0 entries (upstream path drift?)")
+            status = "EMPTY"
+        elif n_entries != n_svgs:
+            errors.append(
+                f"{vendor}: data.json entries ({n_entries}) != src svgs ({n_svgs})"
+            )
+            status = "MISMATCH"
+        click.echo(f"{vendor:<18}{n_entries:>9}{n_svgs:>8}  {status}")
+
+    if errors:
+        click.echo("\nVALIDATION FAILED:")
+        for e in errors:
+            click.echo(f"  - {e}")
+        raise SystemExit(1)
+    click.echo("\nAll vendors valid.")
+
+
 # Expose only cache and dist at the root
 cli.add_command(cache, name="cache")
 cli.add_command(dist, name="dist")
 cli.add_command(clean, name="clean")
+cli.add_command(validate, name="validate")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What

Adds a maintenance CI so the icon mirror stays current without manual work.

- **`.github/workflows/update-icons.yml`** — weekly (Mon 06:00 UTC) + manual `workflow_dispatch`. Bumps all 6 `vendor/*` submodules to latest upstream, rebuilds `dist/` (`uv run main.py dist`), validates, and opens a PR on branch `bot/icons-update`. **No secrets** — every source is a git submodule.
- **`pipeline/main.py`** — new `uv run main.py validate` command: each vendor's `data.json` must parse, list >0 files, and match the `.svg` count in `src/`. The workflow layers a **>25% regression gate** on top to catch partial upstream path drift (a vendor folder moving would otherwise ship empty silently).
- **`pipeline/README.md`** — documents both.

## Verified locally

- Full `bump → dist → validate` runs in ~8s; deterministic (~398 changed paths of ~14k).
- A dry-run today would add **+224 icons** (svgl +153, lucide +59, octicons +12); phosphor correctly flat.
- `validate` exits non-zero on a simulated emptied vendor; regression-gate arithmetic unit-tested.

## Notes

- Fork guard pinned to `gridaco/icons` (this repo; `reflect-ui/icons` redirects here).
- The data refresh always lands via the bot's own PR, not this one.
- `version` in each `data.json` is template-pinned, not auto-derived from the submodule — bump by hand on upstream releases (documented).

## To enable

Requires *Settings → Actions → General → "Allow GitHub Actions to create and approve pull requests."*