### PR TITLE
feat: zero-cost icon search, per-icon SEO pages, and public API docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,38 @@
+# AGENTS.md
+
+Guidance for coding agents working in this repository. (v1 — minimal)
+
+## What this is
+
+Grida Icons — an aggregated, enriched catalog of open-source icons with a free
+public search API and a Next.js web app.
+
+## Layout
+
+- `vendor/` — upstream icon sources (git submodules).
+- `pipeline/` — Python tooling that builds `dist/` and enriches per-icon metadata (keywords + descriptions).
+- `dist/<vendor>/data.json` — built catalog; per-icon `{ name, file, properties, description, tags }`.
+- `www/` — Next.js web app: search UI, public API (`app/(api)/`), docs at `/docs`.
+
+## Web app (`www/`)
+
+Stack: Next.js 16 (App Router, Turbopack), React 19, Tailwind v4, pnpm, Node 24.
+Lint/format via oxlint + oxfmt (no ESLint/Prettier); a lefthook pre-commit runs them.
+
+```
+pnpm --dir www dev        # run locally
+pnpm --dir www build      # production build
+pnpm --dir www typecheck  # tsc --noEmit
+pnpm --dir www lint       # oxlint
+```
+
+- The client/server search both use the prebuilt index from
+  `www/scripts/build-search-index.mjs` (runs in `predev`/`prebuild`). Its output
+  `www/public/search-index.json` is generated and git-ignored.
+- The public API contract is documented at `/docs` and `/llms.txt`.
+
+## Conventions
+
+- Match the surrounding code style; let oxfmt/oxlint format.
+- Do not commit generated artifacts (`www/public/dist`, `www/public/search-index.json`).
+- Commit only when asked; branch off `main` for changes.

--- a/www/.oxlintrc.json
+++ b/www/.oxlintrc.json
@@ -7,7 +7,8 @@
   "rules": {
     "jsx-a11y/click-events-have-key-events": "warn",
     "jsx-a11y/no-noninteractive-element-interactions": "warn",
-    "jsx-a11y/prefer-tag-over-role": "warn"
+    "jsx-a11y/prefer-tag-over-role": "warn",
+    "nextjs/no-img-element": "off"
   },
   "ignorePatterns": [
     "**/node_modules/**",

--- a/www/app/(api)/api/search/route.ts
+++ b/www/app/(api)/api/search/route.ts
@@ -1,0 +1,67 @@
+import { NextResponse } from "next/server";
+import type MiniSearch from "minisearch";
+import { getCatalog } from "../../catalog";
+import { buildDownloadUrl, CACHE_HEADERS } from "../../lib";
+import { createIndex, type IconDoc, runSearch } from "../../search-core";
+
+export const revalidate = 3600;
+
+const MAX_LIMIT = 500;
+const DEFAULT_LIMIT = 100;
+
+type LoadedIndex = { mini: MiniSearch<IconDoc>; docs: IconDoc[] };
+
+// Built once per server instance (module scope), not per request — avoids
+// re-indexing the catalog on every call.
+let indexPromise: Promise<LoadedIndex> | null = null;
+
+function loadIndex(): Promise<LoadedIndex> {
+  if (!indexPromise) {
+    indexPromise = (async () => {
+      const { icons } = await getCatalog();
+      return { mini: createIndex(icons), docs: icons };
+    })();
+  }
+  return indexPromise;
+}
+
+function parseIntParam(value: string | null, fallback: number, max: number): number {
+  const n = Number.parseInt(value ?? "", 10);
+  if (!Number.isFinite(n) || n < 0) return fallback;
+  return Math.min(n, max);
+}
+
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const q = searchParams.get("q") ?? searchParams.get("name") ?? undefined;
+  const vendor = searchParams.get("vendor") || undefined;
+  const limit = parseIntParam(searchParams.get("limit"), DEFAULT_LIMIT, MAX_LIMIT);
+  const offset = parseIntParam(searchParams.get("offset"), 0, Number.MAX_SAFE_INTEGER);
+
+  const { mini, docs } = await loadIndex();
+  const { total, items } = runSearch(mini, docs, { q, vendor, limit, offset });
+
+  return NextResponse.json(
+    {
+      total,
+      count: items.length,
+      limit,
+      offset,
+      items: items.map((doc) => ({
+        id: doc.id,
+        vendor: doc.vendor,
+        name: doc.name,
+        description: doc.description,
+        tags: doc.tags,
+        download: buildDownloadUrl(doc.vendor, doc.file),
+        url: `/icons/${doc.vendor}/${doc.name}`,
+        variants: doc.variants.map((v) => ({
+          name: v.name,
+          properties: v.properties,
+          download: buildDownloadUrl(doc.vendor, v.file),
+        })),
+      })),
+    },
+    { headers: { ...CACHE_HEADERS } },
+  );
+}

--- a/www/app/(api)/catalog.ts
+++ b/www/app/(api)/catalog.ts
@@ -1,0 +1,34 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import type { IconDoc, SearchIndexFile, VendorMeta } from "./search-core";
+
+// Server-side loader for the prebuilt search index (public/search-index.json).
+// Cached at module scope so the catalog is parsed once per server instance and
+// reused by the /api/search route, the per-icon pages, and the sitemap.
+
+const INDEX_PATH = path.resolve(process.cwd(), "public", "search-index.json");
+
+export type Catalog = {
+  icons: IconDoc[];
+  vendors: Record<string, VendorMeta>;
+  byId: Map<string, IconDoc>;
+};
+
+let catalogPromise: Promise<Catalog> | null = null;
+
+export function getCatalog(): Promise<Catalog> {
+  if (!catalogPromise) {
+    catalogPromise = (async () => {
+      const raw = await fs.readFile(INDEX_PATH, "utf8");
+      const { icons, vendors } = JSON.parse(raw) as SearchIndexFile;
+      const byId = new Map(icons.map((icon) => [icon.id, icon]));
+      return { icons, vendors, byId };
+    })();
+  }
+  return catalogPromise;
+}
+
+export async function getIcon(vendor: string, name: string): Promise<IconDoc | undefined> {
+  const { byId } = await getCatalog();
+  return byId.get(`${vendor}/${name}`);
+}

--- a/www/app/(api)/lib.ts
+++ b/www/app/(api)/lib.ts
@@ -5,6 +5,8 @@ export type FileEntry = {
   name: string;
   file: string;
   properties?: Record<string, unknown>;
+  description?: string;
+  tags?: string[];
 };
 
 export type VendorData = {
@@ -20,6 +22,8 @@ export type ApiItem = {
   name: string;
   download: string;
   properties: Record<string, unknown>;
+  description?: string;
+  tags?: string[];
 };
 
 export type ApiItemsResponse = {
@@ -76,6 +80,13 @@ export function parseItemsQuery(request: Request): ItemsQuery {
 const HOST =
   process.env.NODE_ENV === "production" ? "https://icons.grida.co" : "http://localhost:3001";
 const BASE = `${HOST}/dist`;
+
+/**
+ * Public origin of the site, used for canonical URLs, sitemap, and OpenGraph.
+ * Prefer an explicit env override so preview/staging deploys don't emit
+ * production canonicals; fall back to the asset host.
+ */
+export const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL || HOST;
 const DIST_ROOT = path.resolve(process.cwd(), "public", "dist");
 
 async function readJson<T>(filePath: string): Promise<T | null> {
@@ -87,7 +98,7 @@ async function readJson<T>(filePath: string): Promise<T | null> {
   }
 }
 
-function buildDownloadUrl(vendorId: string, file: string): string {
+export function buildDownloadUrl(vendorId: string, file: string): string {
   return `${BASE}/${vendorId}/${file}`;
 }
 
@@ -114,6 +125,8 @@ export async function buildAllItems() {
       name: f.name,
       download: buildDownloadUrl(id, f.file),
       properties: f.properties ?? {},
+      description: f.description,
+      tags: f.tags,
     })),
   );
   return { items, total: items.length };
@@ -129,6 +142,8 @@ export async function buildSvglItems() {
       name: f.name,
       download: buildDownloadUrl("svgl", f.file),
       properties: f.properties ?? {},
+      description: f.description,
+      tags: f.tags,
     })) ?? [];
   return { items, total: items.length, missing: false };
 }

--- a/www/app/(api)/search-core.ts
+++ b/www/app/(api)/search-core.ts
@@ -1,0 +1,116 @@
+import MiniSearch, { type SearchResult } from "minisearch";
+
+// Shape of one logical icon in public/search-index.json (built by
+// scripts/build-search-index.mjs). Shared by the /api/search route (server) and
+// the web app (client) so both search identically off one index.
+
+export type IconVariant = {
+  file: string;
+  name: string;
+  properties: Record<string, string>;
+};
+
+export type IconDoc = {
+  id: string; // `${vendor}/${name}`
+  vendor: string;
+  name: string;
+  tags: string[];
+  description: string;
+  file: string; // preview/default variant file
+  variants: IconVariant[];
+};
+
+export type VendorMeta = {
+  id: string;
+  name: string;
+  version?: string;
+  url?: string;
+  license?: string;
+  variants?: Record<string, { title?: string; default?: string; enum?: string[] }>;
+};
+
+export type SearchIndexFile = {
+  version: number;
+  count: number;
+  vendors: Record<string, VendorMeta>;
+  icons: IconDoc[];
+};
+
+export type SearchParams = {
+  q?: string;
+  vendor?: string;
+  /** Page size. Omit for no pagination (return all matches after `offset`). */
+  limit?: number;
+  offset?: number;
+};
+
+/** Same-origin static asset path for an icon SVG (served from /dist). */
+export function previewSrc(vendor: string, file: string): string {
+  return `/dist/${vendor}/${file}`;
+}
+
+export type SearchOutcome = {
+  total: number;
+  items: IconDoc[];
+};
+
+// Searchable fields. `keywords` is a synthetic field — the tags array joined
+// into text so each tag is tokenized; it is never stored. `description` is
+// intentionally NOT searchable (display-only until embeddings land). `name` is
+// boosted over keywords. storeFields keep the ORIGINAL shapes (tags as array).
+const SEARCHABLE_FIELDS = ["name", "keywords"] as const;
+const STORE_FIELDS = ["vendor", "name", "description", "file", "variants", "tags"] as const;
+
+export function createIndex(docs: IconDoc[]): MiniSearch<IconDoc> {
+  const mini = new MiniSearch<IconDoc>({
+    idField: "id",
+    fields: [...SEARCHABLE_FIELDS],
+    storeFields: [...STORE_FIELDS],
+    extractField: (doc, field) => {
+      if (field === "keywords") return (doc.tags ?? []).join(" ");
+      // Stored fields (e.g. tags array, variants) are returned as-is.
+      return doc[field as keyof IconDoc] as unknown as string;
+    },
+    searchOptions: {
+      boost: { name: 2 },
+      prefix: true,
+      fuzzy: 0.2,
+    },
+  });
+  mini.addAll(docs);
+  return mini;
+}
+
+function resultToDoc(r: SearchResult): IconDoc {
+  return {
+    id: r.id as string,
+    vendor: r.vendor,
+    name: r.name,
+    tags: r.tags ?? [],
+    description: r.description ?? "",
+    file: r.file,
+    variants: r.variants ?? [],
+  };
+}
+
+/**
+ * Run a query against the prebuilt index. Empty query returns all docs (so the
+ * web app and API share one "browse all + filter" path). Vendor filter and
+ * pagination apply to both branches.
+ */
+export function runSearch(
+  mini: MiniSearch<IconDoc>,
+  docs: IconDoc[],
+  { q, vendor, limit, offset = 0 }: SearchParams,
+): SearchOutcome {
+  const query = q?.trim();
+  let results: IconDoc[] = query ? mini.search(query).map(resultToDoc) : docs;
+
+  if (vendor) {
+    results = results.filter((d) => d.vendor === vendor);
+  }
+
+  const total = results.length;
+  const items = limit === undefined ? results.slice(offset) : results.slice(offset, offset + limit);
+  return { total, items };
+}

--- a/www/app/about/page.tsx
+++ b/www/app/about/page.tsx
@@ -81,7 +81,7 @@ function AppSidebar() {
         <SidebarMenu>
           <SidebarMenuItem>
             <SidebarMenuButton asChild>
-              <Link href="/api">
+              <Link href="/docs">
                 <span>API</span>
               </Link>
             </SidebarMenuButton>

--- a/www/app/docs/page.tsx
+++ b/www/app/docs/page.tsx
@@ -1,0 +1,226 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { SITE_URL } from "../(api)/lib";
+
+export const metadata: Metadata = {
+  title: "API Reference | Grida Icons",
+  description:
+    "Free, public, zero-auth REST API for searching 5,000+ icons across Heroicons, Lucide, Phosphor, Octicons, Radix, and SVGL — with keywords, descriptions, and downloadable SVGs.",
+  alternates: { canonical: "/docs" },
+};
+
+type Param = { name: string; type: string; required?: boolean; desc: string };
+
+function ParamTable({ params }: { params: Param[] }) {
+  return (
+    <div className="mt-4 overflow-hidden rounded-lg border">
+      <table className="w-full text-sm">
+        <thead className="bg-muted/50 text-left text-xs text-muted-foreground">
+          <tr>
+            <th className="px-4 py-2 font-medium">Parameter</th>
+            <th className="px-4 py-2 font-medium">Type</th>
+            <th className="px-4 py-2 font-medium">Description</th>
+          </tr>
+        </thead>
+        <tbody>
+          {params.map((p) => (
+            <tr key={p.name} className="border-t">
+              <td className="px-4 py-2 align-top font-mono text-xs">
+                {p.name}
+                {p.required && <span className="ml-1 text-[10px] text-amber-600">required</span>}
+              </td>
+              <td className="px-4 py-2 align-top font-mono text-xs text-muted-foreground">
+                {p.type}
+              </td>
+              <td className="px-4 py-2 align-top text-muted-foreground">{p.desc}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+function Code({ children }: { children: string }) {
+  return (
+    <pre className="mt-4 overflow-x-auto rounded-lg border bg-muted/40 p-4 text-xs leading-relaxed">
+      <code>{children}</code>
+    </pre>
+  );
+}
+
+function Method({ path }: { path: string }) {
+  return (
+    <div className="flex items-center gap-2 font-mono text-sm">
+      <span className="rounded bg-emerald-600/10 px-2 py-0.5 text-xs font-semibold text-emerald-700">
+        GET
+      </span>
+      <span>{path}</span>
+    </div>
+  );
+}
+
+export default function DocsPage() {
+  const base = SITE_URL;
+
+  return (
+    <main className="mx-auto max-w-3xl px-6 py-12">
+      <nav className="mb-8 text-sm text-muted-foreground">
+        <Link href="/" className="hover:text-foreground">
+          ← Back to Icons
+        </Link>
+      </nav>
+
+      <h1 className="text-3xl font-bold">API Reference</h1>
+      <p className="mt-3 text-base text-muted-foreground">
+        A free, public, zero-auth REST API over the Grida Icons catalog — 5,000+ icons from
+        Heroicons, Lucide, Phosphor, Octicons, Radix UI, and SVGL, enriched with keywords and
+        descriptions. No API key, CORS open to all origins, responses cached at the edge.
+      </p>
+
+      <section className="mt-8">
+        <h2 className="text-sm font-semibold text-muted-foreground">Base URL</h2>
+        <Code>{base}</Code>
+      </section>
+
+      {/* ---------------- Search ---------------- */}
+      <section className="mt-12 border-t pt-8">
+        <h2 className="text-xl font-semibold">Search icons</h2>
+        <p className="mt-2 text-sm text-muted-foreground">
+          Ranked keyword search over icon names and tags (prefix + fuzzy matching). Returns one
+          result per logical icon, with its variants grouped. This is the recommended endpoint for
+          building search UIs.
+        </p>
+        <div className="mt-4">
+          <Method path="/api/search" />
+        </div>
+        <ParamTable
+          params={[
+            { name: "q", type: "string", desc: "Search query (matches name + tags). Alias: name." },
+            { name: "vendor", type: "string", desc: "Restrict to one set, e.g. lucide-icons." },
+            { name: "limit", type: "number", desc: "Page size. Default 100, max 500." },
+            { name: "offset", type: "number", desc: "Pagination offset. Default 0." },
+          ]}
+        />
+        <Code>{`curl "${base}/api/search?q=trash&limit=2"`}</Code>
+        <Code>{`{
+  "total": 16,
+  "count": 2,
+  "limit": 2,
+  "offset": 0,
+  "items": [
+    {
+      "id": "heroicons/trash",
+      "vendor": "heroicons",
+      "name": "trash",
+      "description": "Wastebasket symbol indicating the action of deleting data.",
+      "tags": ["trash", "delete", "remove", "bin"],
+      "download": "${base}/dist/heroicons/src/24/outline/trash.svg",
+      "url": "/icons/heroicons/trash",
+      "variants": [
+        {
+          "name": "trash",
+          "properties": { "size": "24", "style": "solid" },
+          "download": "${base}/dist/heroicons/src/24/solid/trash.svg"
+        }
+      ]
+    }
+  ]
+}`}</Code>
+      </section>
+
+      {/* ---------------- List ---------------- */}
+      <section className="mt-12 border-t pt-8">
+        <h2 className="text-xl font-semibold">List icons</h2>
+        <p className="mt-2 text-sm text-muted-foreground">
+          Lists every icon file (each variant is a separate item). Filtering is exact substring on
+          name. Use <span className="font-mono text-xs">/api/search</span> for ranked search.
+        </p>
+        <div className="mt-4">
+          <Method path="/api" />
+        </div>
+        <ParamTable
+          params={[
+            { name: "vendor", type: "string", desc: "Restrict to one set." },
+            { name: "q", type: "string", desc: "Case-insensitive substring on the icon name." },
+            {
+              name: "variant:<key>",
+              type: "string",
+              desc: "Filter by a variant property, e.g. variant:style=solid or variant:weight=bold.",
+            },
+          ]}
+        />
+        <Code>{`curl "${base}/api?vendor=phosphor-icons&variant:weight=bold"`}</Code>
+      </section>
+
+      {/* ---------------- Logos ---------------- */}
+      <section className="mt-12 border-t pt-8">
+        <h2 className="text-xl font-semibold">Brand logos (SVGL)</h2>
+        <p className="mt-2 text-sm text-muted-foreground">
+          Same shape as <span className="font-mono text-xs">/api</span>, scoped to the SVGL brand
+          logo set (light/dark themes, symbol/wordmark kinds).
+        </p>
+        <div className="mt-4">
+          <Method path="/api/logos" />
+        </div>
+        <Code>{`curl "${base}/api/logos?variant:theme=dark"`}</Code>
+      </section>
+
+      {/* ---------------- Vendors ---------------- */}
+      <section className="mt-12 border-t pt-8">
+        <h2 className="text-xl font-semibold">List sets</h2>
+        <p className="mt-2 text-sm text-muted-foreground">
+          Metadata for every icon set, including its variant axes and counts.
+        </p>
+        <div className="mt-4">
+          <Method path="/api/vendors" />
+        </div>
+        <Code>{`{
+  "total": 6,
+  "items": [
+    {
+      "id": "heroicons",
+      "name": "Heroicons",
+      "version": "2.2.0",
+      "count": 1288,
+      "variants": {
+        "size": { "title": "Size", "default": "24", "enum": ["16", "20", "24"] },
+        "style": { "title": "Style", "default": "outline", "enum": ["solid", "outline"] }
+      }
+    }
+  ]
+}`}</Code>
+      </section>
+
+      {/* ---------------- Assets ---------------- */}
+      <section className="mt-12 border-t pt-8">
+        <h2 className="text-xl font-semibold">Raw SVG assets</h2>
+        <p className="mt-2 text-sm text-muted-foreground">
+          Every <span className="font-mono text-xs">download</span> URL points at the raw SVG,
+          served with <span className="font-mono text-xs">Access-Control-Allow-Origin: *</span> and
+          an immutable one-year cache — safe to hotlink or embed directly.
+        </p>
+        <div className="mt-4">
+          <Method path="/dist/{vendor}/{file}" />
+        </div>
+        <Code>{`<img src="${base}/dist/lucide-icons/src/arrow-up.svg" width="24" height="24" />`}</Code>
+      </section>
+
+      {/* ---------------- Notes ---------------- */}
+      <section className="mt-12 border-t pt-8">
+        <h2 className="text-xl font-semibold">Notes</h2>
+        <ul className="mt-3 list-disc space-y-2 pl-5 text-sm text-muted-foreground">
+          <li>No authentication. All endpoints accept GET and respond with JSON.</li>
+          <li>
+            CORS is open to every origin; responses set{" "}
+            <span className="font-mono text-xs">s-maxage=3600, stale-while-revalidate=86400</span>.
+          </li>
+          <li>
+            Each icon set keeps its upstream license — review the source project before
+            redistribution.
+          </li>
+        </ul>
+      </section>
+    </main>
+  );
+}

--- a/www/app/icons/[vendor]/[name]/page.tsx
+++ b/www/app/icons/[vendor]/[name]/page.tsx
@@ -1,0 +1,211 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { getCatalog, getIcon } from "@/app/(api)/catalog";
+import { buildDownloadUrl, SITE_URL } from "@/app/(api)/lib";
+import { type IconDoc, previewSrc, type VendorMeta } from "@/app/(api)/search-core";
+
+// Long tail renders on first visit and is cached (ISR); a small seed subset is
+// pre-rendered at build time. Avoids building ~5k pages up front.
+export const dynamicParams = true;
+export const revalidate = 86400;
+
+type Params = { vendor: string; name: string };
+
+const SEED_PER_VENDOR = 50;
+
+// Non-empty seed so the route deploys as ISR without a build-time blow-up.
+export async function generateStaticParams(): Promise<Params[]> {
+  const { icons } = await getCatalog();
+  const perVendor = new Map<string, number>();
+  const seed: Params[] = [];
+  for (const icon of icons) {
+    const n = perVendor.get(icon.vendor) ?? 0;
+    if (n >= SEED_PER_VENDOR) continue;
+    perVendor.set(icon.vendor, n + 1);
+    seed.push({ vendor: icon.vendor, name: icon.name });
+  }
+  return seed;
+}
+
+async function resolve(params: Promise<Params>): Promise<{ icon: IconDoc; vendor: VendorMeta }> {
+  const { vendor, name } = await params;
+  const icon = await getIcon(vendor, decodeURIComponent(name));
+  if (!icon) notFound();
+  const { vendors } = await getCatalog();
+  return { icon, vendor: vendors[icon.vendor] ?? { id: icon.vendor, name: icon.vendor } };
+}
+
+export async function generateMetadata({ params }: { params: Promise<Params> }): Promise<Metadata> {
+  const { vendor, name } = await params;
+  const icon = await getIcon(vendor, decodeURIComponent(name));
+  if (!icon) return { title: "Icon not found | Grida Icons" };
+
+  const { vendors } = await getCatalog();
+  const vendorName = vendors[icon.vendor]?.name ?? icon.vendor;
+  const title = `${icon.name} icon — ${vendorName} | Grida Icons`;
+  const description =
+    icon.description ||
+    `Download the "${icon.name}" icon from ${vendorName} as SVG. Free and open source.`;
+  const canonical = `/icons/${icon.vendor}/${encodeURIComponent(icon.name)}`;
+  const ogImage = buildDownloadUrl(icon.vendor, icon.file);
+
+  return {
+    title,
+    description,
+    keywords: icon.tags,
+    alternates: { canonical },
+    openGraph: {
+      type: "article",
+      title,
+      description,
+      url: canonical,
+      siteName: "Grida Icons",
+      images: [{ url: ogImage, width: 512, height: 512, alt: `${icon.name} icon` }],
+    },
+    twitter: {
+      card: "summary",
+      title,
+      description,
+      images: [ogImage],
+    },
+  };
+}
+
+export default async function IconPage({ params }: { params: Promise<Params> }) {
+  const { icon, vendor } = await resolve(params);
+  const preview = previewSrc(icon.vendor, icon.file);
+  const rawUrl = buildDownloadUrl(icon.vendor, icon.file);
+  // svgl logos are full-color brand marks — never invert them like monochrome icons.
+  const isSvgl = icon.vendor === "svgl";
+
+  const jsonLd = {
+    "@context": "https://schema.org",
+    "@type": "ImageObject",
+    name: `${icon.name} icon`,
+    description: icon.description || `The "${icon.name}" icon from ${vendor.name}.`,
+    contentUrl: rawUrl,
+    encodingFormat: "image/svg+xml",
+    keywords: icon.tags.join(", "),
+    isAccessibleForFree: true,
+    license: vendor.url,
+    creator: { "@type": "Organization", name: vendor.name, url: vendor.url },
+    url: `${SITE_URL}/icons/${icon.vendor}/${encodeURIComponent(icon.name)}`,
+  };
+
+  return (
+    <main className="mx-auto max-w-3xl px-6 py-10">
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+      />
+
+      <nav className="mb-6 text-sm text-muted-foreground">
+        <Link href="/" className="hover:text-foreground">
+          Icons
+        </Link>
+        <span className="mx-2">/</span>
+        <Link href={`/?vendor=${icon.vendor}`} className="hover:text-foreground">
+          {vendor.name}
+        </Link>
+        <span className="mx-2">/</span>
+        <span className="text-foreground">{icon.name}</span>
+      </nav>
+
+      <div className="flex flex-col gap-8 sm:flex-row sm:items-start">
+        <div className="flex h-40 w-40 shrink-0 items-center justify-center rounded-2xl border bg-muted/40">
+          <img
+            src={preview}
+            alt={`${icon.name} icon`}
+            className={isSvgl ? "h-20 w-20 object-contain" : "h-20 w-20 object-contain dark:invert"}
+          />
+        </div>
+
+        <div className="flex-1">
+          <h1 className="text-2xl font-bold">{icon.name}</h1>
+          <p className="mt-1 text-sm text-muted-foreground">
+            {vendor.name}
+            {vendor.version ? ` · v${vendor.version}` : ""}
+          </p>
+
+          {icon.description && <p className="mt-4 text-base">{icon.description}</p>}
+
+          <div className="mt-6 flex flex-wrap gap-3">
+            <a
+              href={rawUrl}
+              download
+              className="inline-flex items-center rounded-md bg-foreground px-4 py-2 text-sm font-medium text-background hover:opacity-90"
+            >
+              Download SVG
+            </a>
+            <a
+              href={rawUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center rounded-md border px-4 py-2 text-sm font-medium hover:bg-muted"
+            >
+              View raw
+            </a>
+          </div>
+        </div>
+      </div>
+
+      {icon.tags.length > 0 && (
+        <section className="mt-10">
+          <h2 className="text-sm font-semibold text-muted-foreground">Keywords</h2>
+          <div className="mt-3 flex flex-wrap gap-2">
+            {icon.tags.map((tag) => (
+              <Link
+                key={tag}
+                href={`/?q=${encodeURIComponent(tag)}`}
+                className="rounded-full border bg-card px-3 py-1 text-xs hover:bg-muted"
+              >
+                {tag}
+              </Link>
+            ))}
+          </div>
+        </section>
+      )}
+
+      {icon.variants.length > 1 && (
+        <section className="mt-10">
+          <h2 className="text-sm font-semibold text-muted-foreground">
+            Variants ({icon.variants.length})
+          </h2>
+          <div className="mt-3 grid grid-cols-2 gap-3 sm:grid-cols-3 md:grid-cols-4">
+            {icon.variants.map((v) => {
+              const dark = isSvgl && v.properties?.theme === "dark";
+              return (
+                <a
+                  key={v.file}
+                  href={buildDownloadUrl(icon.vendor, v.file)}
+                  download
+                  className={
+                    dark
+                      ? "flex flex-col items-center gap-2 rounded-lg border border-neutral-700 bg-neutral-900 p-4 text-center hover:opacity-90"
+                      : "flex flex-col items-center gap-2 rounded-lg border bg-card/60 p-4 text-center hover:bg-muted"
+                  }
+                >
+                  <img
+                    src={previewSrc(icon.vendor, v.file)}
+                    alt={v.name}
+                    className={
+                      isSvgl ? "h-8 w-8 object-contain" : "h-8 w-8 object-contain dark:invert"
+                    }
+                  />
+                  <span
+                    className={
+                      dark ? "text-[11px] text-neutral-400" : "text-[11px] text-muted-foreground"
+                    }
+                  >
+                    {Object.values(v.properties).join(" · ") || v.name}
+                  </span>
+                </a>
+              );
+            })}
+          </div>
+        </section>
+      )}
+    </main>
+  );
+}

--- a/www/app/layout.tsx
+++ b/www/app/layout.tsx
@@ -1,5 +1,7 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
+import { NuqsAdapter } from "nuqs/adapters/next/app";
+import { SITE_URL } from "./(api)/lib";
 import "./globals.css";
 
 const geistSans = Geist({
@@ -13,7 +15,11 @@ const geistMono = Geist_Mono({
 });
 
 export const metadata: Metadata = {
-  title: "Grida Icons - Icon Library",
+  metadataBase: new URL(SITE_URL),
+  title: {
+    default: "Grida Icons - Icon Library",
+    template: "%s",
+  },
   description:
     "A comprehensive icon library with rich metadata for easy search, preview, and import.",
 };
@@ -25,7 +31,9 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body className={`${geistSans.variable} ${geistMono.variable} antialiased`}>{children}</body>
+      <body className={`${geistSans.variable} ${geistMono.variable} antialiased`}>
+        <NuqsAdapter>{children}</NuqsAdapter>
+      </body>
     </html>
   );
 }

--- a/www/app/page.tsx
+++ b/www/app/page.tsx
@@ -1,9 +1,10 @@
 "use client";
 
-import { useEffect, useMemo, useRef, useState } from "react";
+import { Suspense, useDeferredValue, useEffect, useMemo, useRef, useState } from "react";
 import Link from "next/link";
-import Image from "next/image";
+import { parseAsString, useQueryState } from "nuqs";
 import { Search } from "lucide-react";
+import type MiniSearch from "minisearch";
 import { GridaLogo } from "@/components/grida-logo";
 import {
   Sidebar,
@@ -20,36 +21,48 @@ import {
 } from "@/components/ui/sidebar";
 import { Button } from "@/components/ui/button";
 import { InputGroup, InputGroupAddon, InputGroupInput } from "@/components/ui/input-group";
+import { Skeleton } from "@/components/ui/skeleton";
 import { useVirtualizer } from "@tanstack/react-virtual";
+import {
+  createIndex,
+  type IconDoc,
+  type IconVariant,
+  previewSrc,
+  runSearch,
+  type SearchIndexFile,
+  type VendorMeta,
+} from "./(api)/search-core";
 
-type IconItem = {
-  vendor: string;
-  version?: string;
-  name: string;
-  download: string;
-  properties: Record<string, unknown>;
-};
+type Catalog = { index: MiniSearch<IconDoc>; docs: IconDoc[]; vendors: VendorMeta[] };
 
-type ApiResponse = {
-  total: number;
-  count: number;
-  items: IconItem[];
-};
+// Stable empty fallbacks so derived values keep a constant reference before load.
+const EMPTY_DOCS: IconDoc[] = [];
+const EMPTY_VENDORS: VendorMeta[] = [];
 
-type VendorItem = {
-  id: string;
-  name?: string;
-  version?: string;
-  count?: number;
-  variants?: Record<
-    string,
-    {
-      title?: string;
-      default?: string;
-      enum?: string[];
-    }
-  >;
-};
+/**
+ * Resolve which variant to preview for a logical icon given the active variant
+ * filters. Returns null when filters are active but no variant matches (so the
+ * icon is excluded), mirroring the old per-file filter behavior.
+ */
+function resolveVariant(
+  icon: IconDoc,
+  variantFilters: Record<string, string | undefined>,
+): IconVariant | null {
+  const active = Object.entries(variantFilters).filter(([, v]) => Boolean(v));
+  if (!active.length) {
+    return icon.variants.find((v) => v.file === icon.file) ?? icon.variants[0] ?? null;
+  }
+  return (
+    icon.variants.find((v) =>
+      active.every(([key, value]) => String(v.properties?.[key]) === String(value)),
+    ) ?? null
+  );
+}
+
+/** svgl "dark" logos are light-colored and need a dark tile to be visible. */
+function isDarkLogo(vendor: string, variant: IconVariant): boolean {
+  return vendor === "svgl" && variant.properties?.theme === "dark";
+}
 
 function AppSidebar({
   vendors,
@@ -120,7 +133,7 @@ function AppSidebar({
         <SidebarMenu>
           <SidebarMenuItem>
             <SidebarMenuButton asChild>
-              <Link href="/api">
+              <Link href="/docs">
                 <span>API</span>
               </Link>
             </SidebarMenuButton>
@@ -138,83 +151,76 @@ function AppSidebar({
   );
 }
 
-export default function Home() {
-  const [icons, setIcons] = useState<IconItem[]>([]);
-  const [vendors, setVendors] = useState<VendorItem[]>([]);
-  const [search, setSearch] = useState("");
-  const [vendorFilter, setVendorFilter] = useState<string | undefined>(undefined);
-  const [loading, setLoading] = useState(false);
-  const [variantFilters, setVariantFilters] = useState<Record<string, string | undefined>>({});
-  const listParentRef = useRef<HTMLDivElement | null>(null);
-  const [columns, setColumns] = useState(2);
+// URL is the source of truth for `q` and `vendor` (via nuqs) so views are
+// shareable and browser back/forward navigates between them. Typing updates `q`
+// optimistically while the URL write is throttled (replace = no history spam);
+// selecting a set pushes a history entry.
+function IconsExplorer() {
+  const [search, setSearch] = useQueryState(
+    "q",
+    parseAsString.withDefault("").withOptions({ throttleMs: 250, clearOnDefault: true }),
+  );
+  const [vendorFilter, setVendorFilter] = useQueryState(
+    "vendor",
+    parseAsString.withOptions({ history: "push", clearOnDefault: true }),
+  );
 
+  // Keep typing fluid: the input tracks `search`, but the heavy filter reads a
+  // deferred value so the 5k-item recompute never blocks keystrokes.
+  const deferredSearch = useDeferredValue(search);
+  const isStale = deferredSearch !== search;
+
+  const [catalog, setCatalog] = useState<Catalog | null>(null);
+  // Explicit per-axis variant picks. Absent = use the vendor's default; "" = show
+  // all (no filter on that axis). Stale keys from another vendor are harmless
+  // because the effective filter only reads the active vendor's axes.
+  const [variantSelections, setVariantSelections] = useState<Record<string, string>>({});
+  const listParentRef = useRef<HTMLDivElement | null>(null);
+  const [gridWidth, setGridWidth] = useState(0);
+
+  const loading = catalog === null;
+  const index = catalog?.index ?? null;
+  const docs = catalog?.docs ?? EMPTY_DOCS;
+  const vendors = catalog?.vendors ?? EMPTY_VENDORS;
+
+  // Load the prebuilt search index once and build MiniSearch in-memory. It
+  // carries both the icons and vendor metadata, so no other fetch is needed and
+  // all subsequent searches are local — no network per keystroke.
   useEffect(() => {
     const controller = new AbortController();
-    const loadVendors = async () => {
+    (async () => {
       try {
-        const res = await fetch("/api/vendors", { signal: controller.signal });
+        const res = await fetch("/search-index.json", { signal: controller.signal });
         if (!res.ok) return;
-        const data: { items: VendorItem[] } = await res.json();
-        setVendors(data.items);
+        const data: SearchIndexFile = await res.json();
+        setCatalog({
+          index: createIndex(data.icons),
+          docs: data.icons,
+          vendors: Object.values(data.vendors),
+        });
       } catch (err) {
         if (err instanceof DOMException && err.name === "AbortError") return;
         console.error(err);
       }
-    };
-    loadVendors();
+    })();
     return () => controller.abort();
   }, []);
 
-  useEffect(() => {
-    const controller = new AbortController();
-    const load = async () => {
-      setLoading(true);
-      try {
-        const params = new URLSearchParams();
-        if (search.trim()) params.set("q", search.trim());
-        if (vendorFilter) params.set("vendor", vendorFilter);
-        Object.entries(variantFilters).forEach(([key, value]) => {
-          if (value) params.set(`variant:${key}`, value);
-        });
-        const res = await fetch(`/api?${params.toString()}`, {
-          signal: controller.signal,
-        });
-        if (!res.ok) return;
-        const data: ApiResponse = await res.json();
-        setIcons(data.items);
-      } catch (err) {
-        if (err instanceof DOMException && err.name === "AbortError") return;
-        console.error(err);
-      } finally {
-        setLoading(false);
-      }
-    };
-    load();
-    return () => controller.abort();
-  }, [search, vendorFilter, variantFilters]);
-
-  // Reset variant filters when the vendor changes, preferring vendor defaults
-  useEffect(() => {
-    const vendor = vendors.find((v) => v.id === vendorFilter);
-    if (!vendor?.variants) {
-      setVariantFilters({});
-      return;
-    }
-    const defaults: Record<string, string | undefined> = {};
-    for (const [key, spec] of Object.entries(vendor.variants)) {
-      defaults[key] = spec.default;
-    }
-    setVariantFilters(defaults);
-  }, [vendorFilter, vendors]);
+  // Logical-icon counts per vendor, derived from the index.
+  const countsByVendor = useMemo(() => {
+    const map = new Map<string, number>();
+    for (const d of docs) map.set(d.vendor, (map.get(d.vendor) ?? 0) + 1);
+    return map;
+  }, [docs]);
 
   const vendorsWithCounts = useMemo(
     () =>
       vendors.map((v) => ({
         id: v.id,
         name: v.name,
-        count: v.count ?? 0,
+        count: countsByVendor.get(v.id) ?? 0,
       })),
-    [vendors],
+    [vendors, countsByVendor],
   );
 
   const activeVendor = useMemo(
@@ -222,46 +228,86 @@ export default function Home() {
     [vendors, vendorFilter],
   );
 
-  // Keep a simple breakpoint-based column count to align with the grid classes
+  // Effective filters, derived during render (no effect): each axis falls back to
+  // the vendor default; "" means "All" (no filter on that axis).
+  const variantFilters = useMemo(() => {
+    const spec = activeVendor?.variants;
+    if (!spec) return {} as Record<string, string>;
+    const out: Record<string, string> = {};
+    for (const [key, s] of Object.entries(spec)) {
+      const value = variantSelections[key] ?? s.default;
+      if (value) out[key] = value;
+    }
+    return out;
+  }, [activeVendor, variantSelections]);
+
+  // In-memory search + vendor filter, then variant-aware preview resolution.
+  const icons = useMemo(() => {
+    if (!index) return [] as { icon: IconDoc; src: string; dark: boolean }[];
+    const { items } = runSearch(index, docs, {
+      q: deferredSearch,
+      vendor: vendorFilter ?? undefined,
+    });
+    const out: { icon: IconDoc; src: string; dark: boolean }[] = [];
+    for (const icon of items) {
+      const variant = resolveVariant(icon, variantFilters);
+      if (variant) {
+        out.push({
+          icon,
+          src: previewSrc(icon.vendor, variant.file),
+          dark: isDarkLogo(icon.vendor, variant),
+        });
+      }
+    }
+    return out;
+  }, [index, docs, deferredSearch, vendorFilter, variantFilters]);
+
+  // Density-based columns: aim for ~TARGET-wide cells (auto-fill), so cells stay
+  // compact and square at any width instead of ballooning at low column counts.
+  const TARGET_CELL = 148;
   useEffect(() => {
     if (typeof window === "undefined") return;
     const node = listParentRef.current;
     if (!node) return;
 
-    const calcColumns = (width: number) => {
-      if (width >= 1280) return 6; // xl
-      if (width >= 1024) return 5; // lg
-      if (width >= 768) return 4; // md
-      if (width >= 640) return 3; // sm
-      return 2;
+    const measure = (width: number) => {
+      if (width > 0) setGridWidth(width);
     };
 
     const resizeObserver = new ResizeObserver((entries) => {
       const entry = entries[0];
-      if (!entry) return;
-      const next = calcColumns(entry.contentRect.width);
-      setColumns((prev) => (prev === next ? prev : next));
+      if (entry) measure(entry.contentRect.width);
     });
 
     resizeObserver.observe(node);
-    setColumns(calcColumns(node.getBoundingClientRect().width));
-
     return () => resizeObserver.disconnect();
   }, []);
 
+  // Square cells sized to the measured width, so the bordered grid tiles exactly.
+  const columns = gridWidth > 0 ? Math.max(2, Math.round(gridWidth / TARGET_CELL)) : 6;
+  const cellSize = gridWidth > 0 ? Math.floor(gridWidth / columns) : TARGET_CELL;
   const rowCount = Math.ceil(icons.length / Math.max(columns, 1));
 
   const virtual = useVirtualizer({
     count: rowCount,
     getScrollElement: () => listParentRef.current,
-    estimateSize: () => 220, // card height incl. gap/padding
-    overscan: 8,
+    estimateSize: () => cellSize,
+    overscan: 6,
   });
+
+  // Re-measure rows when the cell size changes (column/width breakpoint).
+  useEffect(() => {
+    virtual.measure();
+  }, [cellSize, virtual]);
 
   return (
     <SidebarProvider>
       <div className="flex h-screen w-full bg-background">
-        <AppSidebar vendors={vendorsWithCounts} active={vendorFilter} onSelect={setVendorFilter} />
+        <AppSidebar
+          vendors={vendorsWithCounts}
+          active={vendorFilter ?? undefined}
+          onSelect={(id) => setVendorFilter(id ?? null)}
+        />
         <main className="flex flex-1 flex-col overflow-hidden">
           <div className="border-b bg-card/40 px-6 py-4 backdrop-blur">
             <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
@@ -270,14 +316,16 @@ export default function Home() {
                   {loading ? "Loading icons..." : `Showing ${icons.length} icons`}
                 </p>
                 {vendorFilter && (
-                  <p className="text-xs text-muted-foreground">Filtered by {vendorFilter}</p>
+                  <p className="text-xs text-muted-foreground">
+                    Filtered by {activeVendor?.name ?? vendorFilter}
+                  </p>
                 )}
               </div>
               <div className="w-full max-w-md">
                 <InputGroup>
                   <InputGroupInput
                     type="search"
-                    placeholder="Search icons..."
+                    placeholder="Search icons by name or keyword..."
                     value={search}
                     onChange={(e) => setSearch(e.target.value)}
                   />
@@ -292,108 +340,143 @@ export default function Home() {
           {activeVendor?.variants && Object.keys(activeVendor.variants).length > 0 && (
             <div className="border-b bg-card/30 px-6 py-3">
               <div className="flex flex-wrap gap-4">
-                {Object.entries(activeVendor.variants).map(([key, spec]) => (
-                  <div key={key} className="flex flex-col gap-2">
-                    <div className="flex items-center gap-2">
-                      <span className="text-xs font-semibold text-muted-foreground">
-                        {spec.title ?? key}
-                      </span>
-                      <div className="flex items-center gap-1">
-                        <Button
-                          size="sm"
-                          variant={!variantFilters[key] ? "secondary" : "ghost"}
-                          onClick={() =>
-                            setVariantFilters((prev) => ({
-                              ...prev,
-                              [key]: undefined,
-                            }))
-                          }
-                        >
-                          All
-                        </Button>
-                        {(spec.enum ?? []).map((option) => (
+                {Object.entries(activeVendor.variants).map(([key, spec]) => {
+                  const current = variantSelections[key] ?? spec.default;
+                  return (
+                    <div key={key} className="flex flex-col gap-2">
+                      <div className="flex items-center gap-2">
+                        <span className="text-xs font-semibold text-muted-foreground">
+                          {spec.title ?? key}
+                        </span>
+                        <div className="flex items-center gap-1">
                           <Button
-                            key={option}
                             size="sm"
-                            variant={variantFilters[key] === option ? "secondary" : "ghost"}
-                            onClick={() =>
-                              setVariantFilters((prev) => ({
-                                ...prev,
-                                [key]: option,
-                              }))
-                            }
+                            variant={variantSelections[key] === "" ? "secondary" : "ghost"}
+                            onClick={() => setVariantSelections((prev) => ({ ...prev, [key]: "" }))}
                           >
-                            {option}
+                            All
                           </Button>
-                        ))}
+                          {(spec.enum ?? []).map((option) => (
+                            <Button
+                              key={option}
+                              size="sm"
+                              variant={current === option ? "secondary" : "ghost"}
+                              onClick={() =>
+                                setVariantSelections((prev) => ({ ...prev, [key]: option }))
+                              }
+                            >
+                              {option}
+                            </Button>
+                          ))}
+                        </div>
                       </div>
                     </div>
-                  </div>
-                ))}
+                  );
+                })}
               </div>
             </div>
           )}
 
-          <div className="flex-1 overflow-y-auto p-6" ref={listParentRef}>
-            <div className="relative w-full" style={{ height: virtual.getTotalSize() }}>
-              {virtual.getVirtualItems().map((row) => {
-                const start = row.index * Math.max(columns, 1);
-                const slice = icons.slice(start, start + Math.max(columns, 1));
-                return (
-                  <div
-                    key={row.key}
-                    className="absolute left-0 right-0"
-                    style={{ transform: `translateY(${row.start}px)` }}
-                  >
-                    <div
-                      className="grid gap-4"
-                      style={{
-                        gridTemplateColumns: `repeat(${columns}, minmax(0, 1fr))`,
-                      }}
-                    >
-                      {slice.map((icon) => (
-                        <div key={icon.download} className="h-full">
-                          <Button
-                            variant="ghost"
-                            className="group flex h-full w-full flex-col items-center justify-between gap-3 rounded-xl border bg-card/60 p-4 text-center shadow-sm transition hover:-translate-y-1 hover:shadow-md"
-                            asChild
+          <div className="flex-1 overflow-y-auto" ref={listParentRef}>
+            {loading ? (
+              <GridSkeleton />
+            ) : (
+              <div className="bg-card">
+                <div
+                  className="relative w-full transition-opacity duration-150"
+                  style={{ height: virtual.getTotalSize(), opacity: isStale ? 0.6 : 1 }}
+                >
+                  {virtual.getVirtualItems().map((row) => {
+                    const start = row.index * Math.max(columns, 1);
+                    const slice = icons.slice(start, start + Math.max(columns, 1));
+                    return (
+                      <div
+                        key={row.key}
+                        className="absolute inset-x-0 grid"
+                        style={{
+                          transform: `translateY(${row.start}px)`,
+                          height: row.size,
+                          gridTemplateColumns: `repeat(${columns}, minmax(0, 1fr))`,
+                        }}
+                      >
+                        {slice.map(({ icon, src, dark }) => (
+                          <Link
+                            key={icon.id}
+                            href={`/icons/${icon.vendor}/${encodeURIComponent(icon.name)}`}
+                            title={icon.description || icon.name}
+                            className="group flex flex-col items-center justify-center gap-2.5 border-r border-b p-3 text-center transition-colors hover:bg-accent"
                           >
-                            <a href={icon.download} target="_blank" rel="noopener noreferrer">
-                              <div className="flex h-14 w-14 items-center justify-center rounded-lg border bg-muted/70">
-                                <Image
-                                  src={icon.download}
-                                  alt={icon.name}
-                                  width={32}
-                                  height={32}
-                                  className="h-8 w-8 object-contain"
-                                />
-                              </div>
-                              <div className="flex flex-col items-center gap-1">
-                                <span className="line-clamp-1 text-xs font-medium">
-                                  {icon.name}
-                                </span>
-                                <span className="rounded-full bg-muted px-2 py-0.5 text-[11px] text-muted-foreground group-hover:text-foreground">
-                                  {icon.vendor}
-                                </span>
-                              </div>
-                            </a>
-                          </Button>
-                        </div>
-                      ))}
-                    </div>
-                  </div>
-                );
-              })}
-            </div>
-            {icons.length === 0 && !loading && (
-              <div className="mt-6 text-sm text-muted-foreground">
+                            <div
+                              className={
+                                dark
+                                  ? "flex h-12 w-12 items-center justify-center rounded-lg bg-neutral-900"
+                                  : "flex h-12 w-12 items-center justify-center"
+                              }
+                            >
+                              <img
+                                src={src}
+                                alt={icon.name}
+                                width={28}
+                                height={28}
+                                loading="lazy"
+                                className={
+                                  icon.vendor === "svgl"
+                                    ? "h-7 w-7 object-contain"
+                                    : "h-7 w-7 object-contain dark:invert"
+                                }
+                              />
+                            </div>
+                            <div className="flex w-full flex-col items-center">
+                              <span className="line-clamp-1 max-w-full text-xs font-medium">
+                                {icon.name}
+                              </span>
+                              <span className="text-[10px] text-muted-foreground/70">
+                                {icon.vendor}
+                              </span>
+                            </div>
+                          </Link>
+                        ))}
+                      </div>
+                    );
+                  })}
+                </div>
+              </div>
+            )}
+            {!loading && icons.length === 0 && (
+              <div className="p-6 text-sm text-muted-foreground">
                 No icons found. Try a different search or set.
               </div>
             )}
-            {loading && <div className="mt-6 text-sm text-muted-foreground">Loading...</div>}
           </div>
         </main>
       </div>
     </SidebarProvider>
+  );
+}
+
+function GridSkeleton() {
+  return (
+    <div className="bg-card">
+      <div className="grid grid-cols-3 sm:grid-cols-4 md:grid-cols-6 lg:grid-cols-7 xl:grid-cols-8">
+        {Array.from({ length: 30 }, (_, i) => (
+          <div
+            key={i}
+            className="flex aspect-square flex-col items-center justify-center gap-2.5 border-r border-b p-3"
+          >
+            <Skeleton className="h-12 w-12 rounded-lg" />
+            <Skeleton className="h-2.5 w-2/3" />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export default function Home() {
+  // nuqs/useQueryState reads useSearchParams(), which needs a Suspense boundary.
+  return (
+    <Suspense fallback={<GridSkeleton />}>
+      <IconsExplorer />
+    </Suspense>
   );
 }

--- a/www/app/robots.ts
+++ b/www/app/robots.ts
@@ -1,0 +1,10 @@
+import type { MetadataRoute } from "next";
+import { SITE_URL } from "./(api)/lib";
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: { userAgent: "*", allow: "/" },
+    sitemap: `${SITE_URL}/sitemap.xml`,
+    host: SITE_URL,
+  };
+}

--- a/www/app/sitemap.ts
+++ b/www/app/sitemap.ts
@@ -1,0 +1,30 @@
+import type { MetadataRoute } from "next";
+import { getCatalog } from "./(api)/catalog";
+import { SITE_URL } from "./(api)/lib";
+
+// One sitemap file covers the whole catalog (well under the 50k URL / 50MB
+// per-file limit). Lists home, vendor-filtered views, and every logical icon
+// so crawlers discover the on-demand (ISR) per-icon pages.
+export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
+  const { icons, vendors } = await getCatalog();
+
+  const staticRoutes: MetadataRoute.Sitemap = [
+    { url: `${SITE_URL}/`, changeFrequency: "weekly", priority: 1 },
+    { url: `${SITE_URL}/docs`, changeFrequency: "monthly", priority: 0.5 },
+    { url: `${SITE_URL}/about`, changeFrequency: "monthly", priority: 0.3 },
+  ];
+
+  const vendorRoutes: MetadataRoute.Sitemap = Object.keys(vendors).map((id) => ({
+    url: `${SITE_URL}/?vendor=${id}`,
+    changeFrequency: "weekly",
+    priority: 0.5,
+  }));
+
+  const iconRoutes: MetadataRoute.Sitemap = icons.map((icon) => ({
+    url: `${SITE_URL}/icons/${icon.vendor}/${encodeURIComponent(icon.name)}`,
+    changeFrequency: "monthly",
+    priority: 0.6,
+  }));
+
+  return [...staticRoutes, ...vendorRoutes, ...iconRoutes];
+}

--- a/www/next.config.ts
+++ b/www/next.config.ts
@@ -1,6 +1,9 @@
+import path from "node:path";
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
+  // Pin the workspace root so Turbopack doesn't warn about multiple lockfiles.
+  turbopack: { root: path.join(__dirname) },
   async headers() {
     return [
       // default: all files get CORS

--- a/www/package.json
+++ b/www/package.json
@@ -9,7 +9,9 @@
     "start": "next start",
     "lint": "oxlint",
     "copy-dist": "rm -rf public/dist && cp -R ../dist public/dist",
-    "prebuild": "pnpm run copy-dist"
+    "build-search-index": "node scripts/build-search-index.mjs",
+    "predev": "pnpm run build-search-index",
+    "prebuild": "pnpm run copy-dist && pnpm run build-search-index"
   },
   "dependencies": {
     "@radix-ui/react-dialog": "^1.1.15",
@@ -20,7 +22,9 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "lucide-react": "^0.553.0",
+    "minisearch": "^7.2.0",
     "next": "16.2.7",
+    "nuqs": "^2.8.9",
     "react": "19.2.7",
     "react-dom": "19.2.7",
     "tailwind-merge": "^3.6.0"

--- a/www/pnpm-lock.yaml
+++ b/www/pnpm-lock.yaml
@@ -32,9 +32,15 @@ importers:
       lucide-react:
         specifier: ^0.553.0
         version: 0.553.0(react@19.2.7)
+      minisearch:
+        specifier: ^7.2.0
+        version: 7.2.0
       next:
         specifier: 16.2.7
         version: 16.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      nuqs:
+        specifier: ^2.8.9
+        version: 2.8.9(next@16.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
       react:
         specifier: 19.2.7
         version: 19.2.7
@@ -719,6 +725,9 @@ packages:
   '@radix-ui/rect@1.1.1':
     resolution: {integrity: sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==}
 
+  '@standard-schema/spec@1.0.0':
+    resolution: {integrity: sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==}
+
   '@swc/helpers@0.5.15':
     resolution: {integrity: sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==}
 
@@ -963,6 +972,9 @@ packages:
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
+  minisearch@7.2.0:
+    resolution: {integrity: sha512-dqT2XBYUOZOiC5t2HRnwADjhNS2cecp9u+TJRiJ1Qp/f5qjkeT5APcGPjHw+bz89Ms8Jp+cG4AlE+QZ/QnDglg==}
+
   nanoid@3.3.12:
     resolution: {integrity: sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
@@ -987,6 +999,27 @@ packages:
       babel-plugin-react-compiler:
         optional: true
       sass:
+        optional: true
+
+  nuqs@2.8.9:
+    resolution: {integrity: sha512-8ou6AEwsxMWSYo2qkfZtYFVzngwbKmg4c00HVxC1fF6CEJv3Fwm6eoZmfVPALB+vw8Udo7KL5uy96PFcYe1BIQ==}
+    peerDependencies:
+      '@remix-run/react': '>=2'
+      '@tanstack/react-router': ^1
+      next: '>=14.2.0'
+      react: '>=18.2.0 || ^19.0.0-0'
+      react-router: ^5 || ^6 || ^7
+      react-router-dom: ^5 || ^6 || ^7
+    peerDependenciesMeta:
+      '@remix-run/react':
+        optional: true
+      '@tanstack/react-router':
+        optional: true
+      next:
+        optional: true
+      react-router:
+        optional: true
+      react-router-dom:
         optional: true
 
   oxlint@1.68.0:
@@ -1590,6 +1623,8 @@ snapshots:
 
   '@radix-ui/rect@1.1.1': {}
 
+  '@standard-schema/spec@1.0.0': {}
+
   '@swc/helpers@0.5.15':
     dependencies:
       tslib: 2.8.1
@@ -1773,6 +1808,8 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  minisearch@7.2.0: {}
+
   nanoid@3.3.12: {}
 
   next@16.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
@@ -1798,6 +1835,13 @@ snapshots:
     transitivePeerDependencies:
       - '@babel/core'
       - babel-plugin-macros
+
+  nuqs@2.8.9(next@16.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7):
+    dependencies:
+      '@standard-schema/spec': 1.0.0
+      react: 19.2.7
+    optionalDependencies:
+      next: 16.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
 
   oxlint@1.68.0:
     optionalDependencies:

--- a/www/public/.gitignore
+++ b/www/public/.gitignore
@@ -1,1 +1,3 @@
 dist
+# Generated at build time by scripts/build-search-index.mjs (prebuild step).
+search-index.json

--- a/www/public/llms.txt
+++ b/www/public/llms.txt
@@ -1,0 +1,44 @@
+# Grida Icons
+
+> Free, public, zero-auth REST API for searching 5,000+ open-source icons across
+> Heroicons, Lucide, Phosphor, Octicons, Radix UI, and SVGL — enriched with
+> keywords and descriptions, with directly downloadable SVGs. No API key. CORS is
+> open to all origins and responses are cached at the edge.
+
+Base URL: https://icons.grida.co
+
+## Search API (recommended)
+
+`GET /api/search?q={query}&vendor={set}&limit={n}&offset={n}`
+
+- `q` — keyword query; ranked match over icon name + tags (prefix + fuzzy). Alias: `name`.
+- `vendor` — optional set id: `heroicons`, `lucide-icons`, `phosphor-icons`, `octicons`, `radix-ui-icons`, `svgl`.
+- `limit` — page size, default 100, max 500.
+- `offset` — pagination offset, default 0.
+
+Returns one result per logical icon (variants grouped). Each item:
+`{ id, vendor, name, description, tags[], download (raw SVG url), url (icon page), variants: [{ name, properties, download }] }`
+
+Example:
+
+```
+curl "https://icons.grida.co/api/search?q=trash&limit=2"
+```
+
+## Other endpoints
+
+- `GET /api` — list every icon file (each variant is a separate item). Filter with `vendor`, `q` (substring on name), and `variant:<key>=<value>` (e.g. `variant:style=solid`, `variant:weight=bold`).
+- `GET /api/logos` — brand logos (SVGL); same response shape as `/api`. Variants: `theme` (light/dark), `kind` (symbol/wordmark).
+- `GET /api/vendors` — metadata for every icon set: id, name, version, count, and variant axes.
+- `GET /dist/{vendor}/{file}` — the raw SVG. Served with `Access-Control-Allow-Origin: *` and an immutable 1-year cache; safe to hotlink or embed directly.
+
+## Integration notes
+
+- No authentication. All endpoints accept `GET` and return JSON.
+- Responses set `Cache-Control: s-maxage=3600, stale-while-revalidate=86400`.
+- The `download` field is an absolute, ready-to-embed SVG URL.
+- Each icon set keeps its upstream license — review the source project before redistribution.
+
+## Docs
+
+- [API Reference](https://icons.grida.co/docs): full human-readable documentation with parameter tables and example responses.

--- a/www/scripts/build-search-index.mjs
+++ b/www/scripts/build-search-index.mjs
@@ -1,0 +1,124 @@
+// Build a compact, prebuilt search index consumed by both the client (instant,
+// in-memory MiniSearch) and the /api/search route (server-side MiniSearch).
+//
+// Source of truth is the repo-root `dist/*/data.json` produced by the pipeline.
+// Output is `www/public/search-index.json`, served as a static CDN asset.
+//
+// Icons are grouped into LOGICAL icons: many vendors bake the variant value into
+// the file name (e.g. phosphor `acorn-bold`, octicons `accessibility-16`,
+// svgl `1password-dark`), while heroicons shares one `name` across size/style.
+// We collapse both shapes by stripping a trailing `-{propertyValue}` that comes
+// from the file's OWN `properties` — a value-keyed strip that is safe because we
+// never strip a suffix the file doesn't actually declare as a variant value.
+//
+// Size lever: `description` is included so cards/tooltips/detail pages can show it
+// WITHOUT a second fetch. It is display-only and NOT a searchable field (search is
+// name + tags). Dropping it here would shrink the payload (~2-3MB -> ~300KB gzip)
+// at the cost of needing a per-icon fetch for the description.
+
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
+const WWW_DIR = path.resolve(SCRIPT_DIR, "..");
+const REPO_DIST = path.resolve(WWW_DIR, "..", "dist");
+const PUBLIC_DIST = path.resolve(WWW_DIR, "public", "dist");
+// Prefer the repo dist (always present); fall back to the copied public/dist.
+const DIST_ROOT = fs.existsSync(REPO_DIST) ? REPO_DIST : PUBLIC_DIST;
+const OUT_FILE = path.resolve(WWW_DIR, "public", "search-index.json");
+
+/** Strip a trailing `-{value}` for each of the file's own variant property values. */
+function toBaseName(name, properties) {
+  let base = name;
+  for (const value of Object.values(properties ?? {})) {
+    const suffix = `-${value}`;
+    if (base.endsWith(suffix) && base.length > suffix.length) {
+      base = base.slice(0, -suffix.length);
+    }
+  }
+  return base;
+}
+
+/** Pick the variant matching the vendor's defaults, else the first file. */
+function pickPreview(variants, variantSpec) {
+  const defaults = Object.entries(variantSpec ?? {})
+    .map(([key, spec]) => [key, spec?.default])
+    .filter(([, def]) => def !== undefined);
+  if (defaults.length) {
+    const match = variants.find((v) =>
+      defaults.every(([key, def]) => String(v.properties?.[key]) === String(def)),
+    );
+    if (match) return match;
+  }
+  return variants[0];
+}
+
+function build() {
+  const vendorDirs = fs
+    .readdirSync(DIST_ROOT, { withFileTypes: true })
+    .filter((e) => e.isDirectory() && !e.name.startsWith("."))
+    .map((e) => e.name)
+    .sort();
+
+  const icons = [];
+  const vendors = {};
+  for (const vendorId of vendorDirs) {
+    const dataPath = path.join(DIST_ROOT, vendorId, "data.json");
+    if (!fs.existsSync(dataPath)) continue;
+    const data = JSON.parse(fs.readFileSync(dataPath, "utf8"));
+    const variantSpec = data.variants ?? {};
+    vendors[vendorId] = {
+      id: vendorId,
+      name: data.name ?? vendorId,
+      version: data.version,
+      url: data.url,
+      license: data.license,
+      variants: variantSpec,
+    };
+
+    // Group files by (vendor, baseName).
+    const groups = new Map();
+    for (const f of data.files ?? []) {
+      const base = toBaseName(f.name, f.properties);
+      let g = groups.get(base);
+      if (!g) {
+        g = { base, variants: [], description: "", tags: [] };
+        groups.set(base, g);
+      }
+      g.variants.push({ file: f.file, name: f.name, properties: f.properties ?? {} });
+      // tags/description are identical across a concept's variants — take first non-empty.
+      if (!g.description && f.description) g.description = f.description;
+      if (!g.tags.length && Array.isArray(f.tags) && f.tags.length) g.tags = f.tags;
+    }
+
+    for (const g of groups.values()) {
+      const preview = pickPreview(g.variants, variantSpec);
+      icons.push({
+        id: `${vendorId}/${g.base}`,
+        vendor: vendorId,
+        name: g.base,
+        tags: g.tags,
+        description: g.description,
+        file: preview.file,
+        variants: g.variants,
+      });
+    }
+  }
+
+  // Stable order: vendor, then name.
+  icons.sort((a, b) => a.vendor.localeCompare(b.vendor) || a.name.localeCompare(b.name));
+
+  const payload = { version: 1, count: icons.length, vendors, icons };
+  fs.mkdirSync(path.dirname(OUT_FILE), { recursive: true });
+  fs.writeFileSync(OUT_FILE, JSON.stringify(payload));
+
+  const bytes = fs.statSync(OUT_FILE).size;
+  const withTags = icons.filter((i) => i.tags.length).length;
+  console.log(
+    `[build-search-index] ${icons.length} logical icons (${withTags} with tags) -> ` +
+      `${OUT_FILE} (${(bytes / 1024 / 1024).toFixed(2)} MB) from ${DIST_ROOT}`,
+  );
+}
+
+build();


### PR DESCRIPTION
Builds a free public search experience on top of the per-icon enrichment (keywords + descriptions) landed in #11.

## Search
- **Prebuilt static index** (`scripts/build-search-index.mjs`, runs in `prebuild`): groups the ~14k variant files into **5,123 logical icons**; served as a CDN asset. Generated artifact, gitignored.
- **Shared MiniSearch core** (`app/(api)/search-core.ts`): searches name + tags (prefix + fuzzy, name boosted), reused by both the in-memory client and the server endpoint.
- **Client search is in-memory** — no network per keystroke. `q`/`vendor` live in the URL via **nuqs** (shareable + back/forward), and `useDeferredValue` keeps typing fluid while the 5k-item list filters.

## SEO
- **Per-icon route** `/icons/[vendor]/[name]` with title/description/OpenGraph/JSON-LD. **On-demand ISR** (small seeded subset prerendered) so builds stay fast instead of rendering 5k pages.
- `sitemap.ts` (all logical icons), `robots.ts`, `metadataBase`. `SITE_URL` honors `NEXT_PUBLIC_SITE_URL` so preview deploys don't emit production canonicals.

## API (the public contract)
- New **`GET /api/search`** — ranked, grouped, paginated (`q`, `vendor`, `limit`, `offset`).
- `tags` + `description` surfaced on the existing `/api` and `/api/logos` (additive, backward-compatible).
- New **`/docs`** API reference page documenting every endpoint, params, example responses, and the raw-asset/CORS/caching contract.

## UI
- Full-bleed bordered "Vercel-style" grid (virtualized via `@tanstack/react-virtual`), skeleton loading, and dark tiles for SVGL dark-theme logos.

## Notes
- Adds one dependency: `nuqs`.
- `/api`, `/api/logos`, `/api/vendors` are unchanged in shape (only enriched).
- Verified: `tsc` clean, `oxlint` clean, production build green (312 static pages). The single remaining build warning is the pre-existing `lib.ts` `public/dist` glob, untouched by this PR.