### PR TITLE
feat(pipeline): generate dist/stats.json with icon/logo counts

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,10 @@
 
 **Live:** [icons.grida.co](https://icons.grida.co) · **API:** [`/llms.txt`](https://icons.grida.co/llms.txt) · [API reference](https://icons.grida.co/docs)
 
+[![icons](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fraw.githubusercontent.com%2Fgridaco%2Ficons%2Fmain%2Fdist%2Fstats.json&query=%24.totals.icons.unique&label=icons&color=blue)](./dist/stats.json)
+[![logos](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fraw.githubusercontent.com%2Fgridaco%2Ficons%2Fmain%2Fdist%2Fstats.json&query=%24.totals.logos.unique&label=logos&color=blue)](./dist/stats.json)
+[![svg files](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fraw.githubusercontent.com%2Fgridaco%2Ficons%2Fmain%2Fdist%2Fstats.json&query=%24.totals.files&label=svg%20files&color=informational)](./dist/stats.json)
+
 Grida Icons mirrors several popular open-source icon sets as git submodules,
 runs them through a Python pipeline that normalizes the SVGs and attaches a
 uniform text layer (a one-line `description` + searchable `tags` for every
@@ -12,7 +16,7 @@ icon), and serves the result through a Next.js web app and a zero-auth REST API.
 
 ## Icon sets
 
-Six upstream sets, ~5,000+ logical icons (many more when you count per-style/weight variants). Sources are tracked as submodules under [`vendor/`](./vendor); the published catalog lives in [`dist/`](./dist).
+Six upstream sets, ~5,000 logical icons and logos (many more when you count per-style/weight variants). Exact, build-generated counts live in [`dist/stats.json`](./dist/stats.json) — the badges above read from it, and every `dist` rebuild (including the weekly refresh PR) regenerates it. Sources are tracked as submodules under [`vendor/`](./vendor); the published catalog lives in [`dist/`](./dist).
 
 | Set                | id               | Source                                                              |
 | ------------------ | ---------------- | ------------------------------------------------------------------- |

--- a/dist/README.md
+++ b/dist/README.md
@@ -2,6 +2,13 @@
 
 This directory contains prebuilt icon assets and metadata for each vendor.
 
+At the root:
+
+- `stats.json` — build-generated counts: per-vendor and aggregate `files`
+  (one per variant SVG) and `unique` (logical icons / brands), grouped into
+  `icons` vs `logos`.
+- `LICENSE` — all vendor licenses, aggregated.
+
 Per vendor:
 
 - `data.json` — package-level metadata.

--- a/dist/stats.json
+++ b/dist/stats.json
@@ -1,0 +1,52 @@
+{
+  "totals": {
+    "files": 14216,
+    "unique": 4916,
+    "icons": {
+      "files": 13138,
+      "unique": 4260
+    },
+    "logos": {
+      "files": 1078,
+      "unique": 656
+    }
+  },
+  "vendors": {
+    "radix-ui-icons": {
+      "name": "Radix UI Icons",
+      "kind": "icons",
+      "files": 332,
+      "unique": 332
+    },
+    "heroicons": {
+      "name": "Heroicons",
+      "kind": "icons",
+      "files": 1288,
+      "unique": 324
+    },
+    "lucide-icons": {
+      "name": "Lucide Icons",
+      "kind": "icons",
+      "files": 1714,
+      "unique": 1714
+    },
+    "phosphor-icons": {
+      "name": "Phosphor Icons",
+      "kind": "icons",
+      "files": 9072,
+      "unique": 1512
+    },
+    "octicons": {
+      "name": "Primer Octicons",
+      "kind": "icons",
+      "files": 732,
+      "unique": 378
+    },
+    "svgl": {
+      "name": "SVGL",
+      "kind": "logos",
+      "files": 1078,
+      "unique": 656
+    }
+  }
+}

--- a/pipeline/README.md
+++ b/pipeline/README.md
@@ -34,6 +34,7 @@ Each command writes metadata to `.cache/<vendor>/metadata.json` by default. Use 
 
 - `uv run main.py dist` — clean, re-cache all vendors, and build the published `dist/` (SVGs + per-vendor `data.json` + merged `LICENSE`).
 - `uv run main.py validate` — sanity-check a built `dist/`: every vendor's `data.json` must parse, list >0 files, and have an entry count matching the `.svg` files in `dist/<vendor>/src`. Exits non-zero on failure. This is the gate that catches an upstream submodule moving its folders out from under a hard-coded source path in `dist` (which would otherwise ship an empty vendor silently).
+- `uv run main.py stats` — regenerate `dist/stats.json`: per-vendor and aggregate counts (`files` = one per variant SVG, `unique` = logical icons / brands), grouped into `icons` vs `logos` by the spec template's category. `dist` already writes it as part of the build; the standalone command exists to refresh it without a full rebuild. The file intentionally carries no timestamp so it only diffs when counts change. The root README's badges read from it.
 
 ### Enrichment (text metadata for search)
 

--- a/pipeline/main.py
+++ b/pipeline/main.py
@@ -309,6 +309,9 @@ def dist(ctx):
     # Merge licenses into dist/LICENSE
     _write_merged_license()
 
+    # Build-time count snapshot (dist/stats.json) — consumed by README badges.
+    _write_stats()
+
     click.echo(f"Dist build complete at {DIST_DIR}")
 
 
@@ -331,6 +334,107 @@ DIST_VENDORS = [
     "octicons",
     "svgl",
 ]
+
+_CACHE_COMMANDS = {
+    "radix-ui-icons": process_radix,
+    "heroicons": process_heroicons,
+    "lucide-icons": process_lucide,
+    "phosphor-icons": process_phosphor,
+    "octicons": process_octicons,
+    "svgl": process_svgl,
+}
+
+
+def _logical_name(rec: dict) -> str | None:
+    """
+    Grouping key for variant records in a vendor cache: icon vendors key
+    variants by `name`; svgl groups a brand's symbol/wordmark/theme files
+    under the vendor-native `meta.title`.
+    """
+    name = rec.get("name") or (rec.get("meta") or {}).get("title")
+    if name:
+        return str(name)
+    path = rec.get("dist_path") or rec.get("file")
+    return Path(path).stem if path else None
+
+
+def _compute_stats() -> dict:
+    """
+    Per-vendor and aggregate counts: `files` is one per variant SVG (matches
+    data.json entries), `unique` is logical icons (brands for svgl). Vendor
+    kind comes from the spec template's category URI (icons-ui vs logos).
+    """
+    vendors: dict[str, dict] = {}
+    totals = {"files": 0, "unique": 0}
+    by_kind: dict[str, dict[str, int]] = {}
+    for vendor in DIST_VENDORS:
+        data_path = DIST_DIR / vendor / "data.json"
+        if not data_path.exists():
+            raise SystemExit(f"stats: {data_path} missing — run `dist` first")
+        data = json.loads(data_path.read_text())
+        records = json.loads((CACHE_DIR / vendor / "metadata.json").read_text())
+        unique = {n for n in (_logical_name(r) for r in records) if n}
+        kind = (
+            "logos"
+            if any(str(c).endswith("/logos") for c in data.get("categories") or [])
+            else "icons"
+        )
+        n_files = len(data.get("files") or [])
+        vendors[vendor] = {
+            "name": data.get("name") or vendor,
+            "kind": kind,
+            "files": n_files,
+            "unique": len(unique),
+        }
+        totals["files"] += n_files
+        totals["unique"] += len(unique)
+        agg = by_kind.setdefault(kind, {"files": 0, "unique": 0})
+        agg["files"] += n_files
+        agg["unique"] += len(unique)
+    return {"totals": {**totals, **by_kind}, "vendors": vendors}
+
+
+def _write_stats() -> dict:
+    """
+    Write dist/stats.json. Deliberately carries no timestamp so the file only
+    diffs when counts actually change (keeps the weekly refresh PR clean).
+    """
+    stats = _compute_stats()
+    (DIST_DIR / "stats.json").write_text(json.dumps(stats, indent=2) + "\n")
+    return stats
+
+
+def _echo_stats(stats: dict) -> None:
+    click.echo(f"{'vendor':<18}{'kind':>6}{'files':>8}{'unique':>8}")
+    for vendor, s in stats["vendors"].items():
+        click.echo(f"{vendor:<18}{s['kind']:>6}{s['files']:>8}{s['unique']:>8}")
+    t = stats["totals"]
+    icons = t.get("icons", {"files": 0, "unique": 0})
+    logos = t.get("logos", {"files": 0, "unique": 0})
+    click.echo(
+        f"totals: {t['unique']} unique / {t['files']} files "
+        f"(icons {icons['unique']}/{icons['files']}, logos {logos['unique']}/{logos['files']})"
+    )
+
+
+@click.command(name="stats")
+@click.pass_context
+def stats_cmd(ctx):
+    """
+    Regenerate dist/stats.json from the built dist/ and vendor cache.
+
+    Counts per vendor: `files` (one entry per variant SVG, same as data.json)
+    and `unique` (logical icons; brands for svgl). Needs dist/<vendor>/data.json
+    (run `dist` first); missing cache metadata is rebuilt per vendor, which
+    requires the vendor submodules to be checked out.
+    """
+    for vendor in DIST_VENDORS:
+        if not (CACHE_DIR / vendor / "metadata.json").exists():
+            click.echo(f"  cache miss for {vendor}; building metadata...")
+            ctx.invoke(_CACHE_COMMANDS[vendor], out=CACHE_DIR / vendor)
+    stats = _write_stats()
+    _echo_stats(stats)
+    click.echo(f"Wrote {DIST_DIR / 'stats.json'}")
 
 
 @click.command(name="validate")
@@ -556,6 +660,7 @@ cli.add_command(cache, name="cache")
 cli.add_command(dist, name="dist")
 cli.add_command(clean, name="clean")
 cli.add_command(validate, name="validate")
+cli.add_command(stats_cmd, name="stats")
 cli.add_command(enrich, name="enrich")
 cli.add_command(enrich_validate, name="enrich-validate")
 

--- a/pipeline/templates/README.dist.md
+++ b/pipeline/templates/README.dist.md
@@ -2,6 +2,13 @@
 
 This directory contains prebuilt icon assets and metadata for each vendor.
 
+At the root:
+
+- `stats.json` — build-generated counts: per-vendor and aggregate `files`
+  (one per variant SVG) and `unique` (logical icons / brands), grouped into
+  `icons` vs `logos`.
+- `LICENSE` — all vendor licenses, aggregated.
+
 Per vendor:
 
 - `data.json` — package-level metadata.


### PR DESCRIPTION
## What

Adds a build-generated stats artifact so the catalog's numbers are queryable and visible without CI ever editing the README.

- **`dist/stats.json`** (new) — per-vendor and aggregate counts: `files` (one per variant SVG, matches `data.json` entries) and `unique` (logical icons; brands for svgl), grouped into `icons` vs `logos` via the spec template's category URI. Deliberately carries **no timestamp**, so it only diffs when counts actually change.
- **`pipeline/main.py`** — `main.py dist` now writes `stats.json` at the end of every build (the weekly `update-icons.yml` refresh PR keeps it current with zero workflow changes). A standalone `main.py stats` regenerates it without a full rebuild.
- **`README.md`** — shields.io dynamic-JSON badges (icons / logos / svg files) that read `stats.json` from `main` at view time, plus a pointer to the file. Static text, dynamic numbers.
- Docs: `pipeline/README.md` command reference and the dist README template.

## Current numbers

| | unique | files (variants) |
|---|---|---|
| icons (5 sets) | 4,260 | 13,138 |
| logos (svgl) | 656 | 1,078 |
| **total** | **4,916** | **14,216** |

## Notes

- The badges will render as *invalid* until this lands on `main` (they fetch `raw.githubusercontent.com/gridaco/icons/main/dist/stats.json`).
- Verified locally: `uv run main.py stats` writes the file and prints the table; `uv run main.py validate` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)